### PR TITLE
[+] add node modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 electron-builder.yml
+node_modules/


### PR DESCRIPTION
The `node_modules` folder isn't ignored, causing some git management apps (like GitHub Desktop) to hang and/or crash when doing certain operations. These should be ignored.